### PR TITLE
Refactor geosuggest and EditProfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-redux": "^4.4.5",
     "react-router": "^2.8.1",
     "react-tap-event-plugin": "^1.0.0",
-    "reactstrap": "^3.8.1",
+    "reactstrap": "^3.9.0",
     "redux": "^3.6.0",
     "redux-form": "^6.1.0",
     "redux-form-material-ui": "^4.1.0",

--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -1,7 +1,9 @@
 import React, { Component, PropTypes as T } from 'react'  // eslint-disable-line no-unused-vars
 import Avatar from 'material-ui/Avatar'
 import { connect } from 'react-redux'
+import { Container, Col, Row } from 'reactstrap';
 import Geosuggest from 'react-geosuggest'
+import RaisedButton from 'material-ui/RaisedButton';
 import './EditProfile.css'
 import './GeoSuggest.css'
 import AutoComplete from 'material-ui/AutoComplete'
@@ -17,42 +19,40 @@ class EditProfile extends Component {
     const { profile } = this.props
 
     return (
-      <div className='profile'>
-        <div className="profile-info-section">
-          <div className='sidebar'>
-            <div className="user-avatar">
-              <Avatar size={200} src={profile.picture} />
-              <p className="change-avatar-button">Change</p>
-            </div>
+      <Container fluid='true' className='profile'>
+        <Col md='3' className='sidebar'>
+          <div className="user-avatar">
+            <Avatar size={200} src={profile.picture} />
+            <p className="change-avatar-button">Change</p>
           </div>
-          <div className='main-area'>
-            <label className="form-label">Name</label>
-            <input type="text" defaultValue={profile.name} className="name-input" />
-            <div className="divider"></div>
-            <label className="form-label">Location</label>
-            <div className="location-section">
-              <Geosuggest className="org-input" onSuggestSelect={this.props.onLocationSuggest}/>
-            </div>
-            <label className="form-label">Organization</label>
-            <div className="label-description">You can connect your profile to an organization that is published on Participedia. Begin typing on the organization field below and select the organization from the dropdown list. Or, if you think your organization belongs on Participedia, publish it now by clicking Quick Submit.</div>
-            <div className="org-section">
-              <div className="quick-submit-section">
-                <AutoComplete dataSource={this.props.organizations} />
-
-                <input type="text" className="org-input" placeholder="Begin Typing an Organization" />
-                <a href="#" className="quick-submit-button">Quick Submit</a>
-                <a href="#" className="help-button">?</a>
-              </div>
-              <input type="text" className="org-input" placeholder="Department" />
-              <input type="text" className="org-input" placeholder="Job Title" />
-              <input type="text" className="org-input" placeholder="Website" />
-            </div>
-            <div className="divider"></div>
-            <label className="form-label">Biography</label>
-            <textarea className="biography-input" placeholder="Tell us about yourself"></textarea>
+        </Col>
+        <Col md='7' className='main-area'>
+          <label className="form-label">Name</label>
+          <input type="text" defaultValue={profile.name} className="name-input" />
+          <div className="divider"></div>
+          <label className="form-label">Location</label>
+          <div>
+            <Geosuggest onSuggestSelect={this.props.onLocationSuggest}/>
           </div>
-        </div>
-      </div>
+          <label className="form-label organization">Organization</label>
+          <div className="label-description">You can connect your profile to an organization that is published on Participedia. Begin typing on the organization field below and select the organization from the dropdown list. Or, if you think your organization belongs on Participedia, publish it now by clicking Quick Submit.</div>
+          <Row className='org-field'>
+            <Col md='7'>
+              <AutoComplete className="auto-org" floatingLabelText="Begin Typing an Organization" dataSource={this.props.organizations} />
+            </Col>
+            <Col md='5'>
+              <RaisedButton label="Quick Submit" className="org-submit" primary={true} />
+              <div className="help-button"><a href="#"><span className="question">?</span></a></div>
+            </Col>
+          </Row>
+            <input type="text" className="org-input" placeholder="Department" />
+            <input type="text" className="org-input" placeholder="Job Title" />
+            <input type="text" className="org-input" placeholder="Website" />
+          <div className="divider"></div>
+          <label className="form-label">Biography</label>
+          <textarea className="biography-input" placeholder="Tell us about yourself"></textarea>
+        </Col>
+      </Container>
     )
   }
 }

--- a/src/components/EditProfile.scss
+++ b/src/components/EditProfile.scss
@@ -6,89 +6,50 @@
   color: black;
 }
 
-.profile-info-section {
-  width: 1600px;
-  margin: 0 auto;
-  overflow: hidden;
-  padding-bottom: 0;
-  padding-top: 32px;
+.profile {
+  padding-top: 7%;
+  padding-bottom: 7%;
+}
 
-  @media (max-width: 1599px) {
-    width: 1280px;
+.org-submit {
+  width: 100%;
+  span {
+    text-transform: none !important;
   }
+}
 
-  @media (max-width: 1279px) {
-    width: 960px;
-  }
-
-  @media (max-width: 959px) {
-    width: 640px;
-  }
-
+.org-field {
+  padding-top: 14px;
   @media (max-width: 639px) {
-    width: 320px;
+    padding-bottom: 28px;
+  }  
+  .col-md-7 {
+    >div {
+      width: 100% !important;
+      margin-bottom: 14px;
+      margin-top: -14px !important;
+      .auto-org {
+        width: 100% !important;
+        label {
+          padding-left: 16px;
+        }
+      }
+    }
   }
-
-  .sidebar {
-    padding: 0 32px;
-    width: 200px;
-    float: left;
-  }
-}
-
-@media (max-width: 1279px) {
-  .profile-info-section .sidebar {
-    // padding: 0 16px;
-    // width: 928px;
-  }
-}
-
-@media (max-width: 959px) {
-  .profile-info-section .sidebar {
-    width: 608px;
-    padding-left: 0;
-  }
-}
-
-@media (max-width: 639px) {
-  .profile-info-section .sidebar {
-    width: 288px;
-    padding: 0 16px;
+  .col-md-5 {
+    .org-submit, .help-button {
+      float: left;
+    }
+    .org-submit {
+      width: 80%;
+    }
+    padding-top: 14px;
   }
 }
 
-.profile-info-section .main-area {
-  padding-right: 32px;
-  width: 1248px;
-  float: right;
-}
-
-@media (max-width: 1599px) {
-  .profile-info-section .main-area {
-    width: 928px;
+  .auto-org {
+    font-size: 20px !important;
   }
-}
-
-@media (max-width: 1279px) {
-  .profile-info-section .main-area {
-    width: 638px;
-    // padding-right: 16px;
-    // padding-left: 16px;
-  }
-}
-
-@media (max-width: 959px) {
-  .profile-info-section .main-area {
-    width: 608px;
-  }
-}
-
-@media (max-width: 639px) {
-  .profile-info-section .main-area {
-    width: 288px;
-    padding: 0 16px;
-  }
-}
 
 .sidebar {
   .user-avatar {
@@ -135,19 +96,20 @@
   }
 }
 
-.profile-info-section .main-area {
+.profile .main-area {
   .form-label {
     color: #666;
     font-size: 36px;
     font-weight: 400;
     line-height: 48px;
     margin-bottom: 24px;
-    padding-left: 32px;
     display: block;
     @media (max-width: 639px) {
-      padding-left: 0;
       font-size: 24px;
       line-height: 32px;
+    }
+    &.organization {
+      padding-top: 28px;
     }
   }
   .name-input {
@@ -180,10 +142,6 @@
     color: #333;
     font-weight: 100;
     line-height: 26px;
-    padding: 0 32px;
-    @media (max-width: 639px) {
-      padding: 0;
-    }
   }
   .org-section {
     padding: 32px;
@@ -206,68 +164,44 @@
 
 
   }
-  .org-input,  {
+  .org-input {
     font-size: 20px;
     font-weight: 300;
     padding: 12px 16px;
+    box-sizing: border-box;
     display: block;
     border: 2px solid #eee;
     margin-bottom: 16px;
     width: 400px;
     @media (max-width: 639px) {
       width: 100%;
-      box-sizing: border-box;
     }
   }
 
-  .org-input.geosuggest {
-    padding: 0;
-  }
-  .quick-submit-section {
-    overflow: hidden;
-    .org-input {
-      float: left;
-    }
-    .quick-submit-button {
+  .help-button {
+    width: 20%;
+    a {
       display: block;
-      float: left;
-      width: 240px;
-      text-align: center;
-      padding: 15px;
-      background-color: #3f51b2;
-      color: #fff;
-      border-radius: 4px;
-      margin-left: 16px;
-      font-size: 20px;
-      font-weight: 400;
-      @media (max-width: 1279px) {
-        width: 406px;
-        margin-left: 0;
-        margin-bottom: 16px;
-      }
-      @media (max-width: 639px) {
-        width: 190px;
-      }
-    }
-    .help-button {
-      display: block;
+      margin: 0 auto;
+      position: relative;
       border: 4px solid #ddd;
       color: #ddd;
-      float: left;
-      font-size: 40px;
-      width: 48px;
-      height: 48px;
+      width: 2.4em;
+      height: 2.4em;
       text-align: center;
-      border-radius: 24px;
+      border-radius: 50%;
       box-sizing: border-box;
-      padding-top: 4px;
-      margin-left: 16px;
+      .question {
+        position: absolute;
+        font-size: 1.7rem;
+        left: 25%;
+        top: -3px;
+      }
     }
   }
   .biography-input {
     display: block;
     border: 2px solid #eee;
-    margin: 0px 32px 64px;
     font-weight: 300;
     padding: 16px;
     width: 100%;
@@ -275,15 +209,7 @@
     height: 240px;
     line-height: 28px;
     font-size: 20px;
-    @media (max-width: 639px) {
-      margin: 0;
-      margin-bottom: 64px;
-    }
   }
-
-
-
-
 
   .name {
     color: #3f51b2;
@@ -337,52 +263,3 @@
     }
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/components/GeoSuggest.scss
+++ b/src/components/GeoSuggest.scss
@@ -1,34 +1,42 @@
 /**
  * The geosuggest module
+ * NOTE: duplicated font-sizes' are for browsers which don't support rem (only IE 8)
  */
 .geosuggest {
-  font-size: inherit;
   position: relative;
-  // width: 100%;
-  margin: 1em 0;
   text-align: left;
+  @media (max-width: 639px) {
+    width: 100%;
+  }
 }
 .geosuggest__input {
-  font-size: inherit;
-  padding: 0;
-  margin: 0;
-  border: 2px solid transparent;
-  padding: 12px 16px;
-  width: 400px;
-  // box-shadow: 0 0 1px #3d464d;
-  // padding: .5em 1em;
-  -webkit-transition: border 0.2s, box-shadow 0.2s;
-          transition: border 0.2s, box-shadow 0.2s;
+  border: none;
+  width: 98%;
 }
+
+.geosuggest__input-wrapper {
+  border: 2px solid #eee;
+  width: 400px;
+  @media (max-width: 639px) {
+    width: 100%;
+  }
+  padding: 16px;
+  box-sizing: border-box;
+  input {
+    font-size: 20px;
+  }
+}
+  
 .geosuggest__input:focus {
   border-color: #267dc0;
   box-shadow: 0 0 0 transparent;
 }
+
 .geosuggest__suggests {
+  width: 400px;
   position: absolute;
   top: 100%;
   left: 0;
-  right: 0;
   max-height: 25em;
   padding: 0;
   margin-top: -1px;
@@ -39,13 +47,28 @@
   overflow-y: auto;
   list-style: none;
   z-index: 5;
-  -webkit-transition: max-height 0.2s, border 0.2s;
-          transition: max-height 0.2s, border 0.2s;
+  box-sizing: border-box;
+  @media (max-width: 639px) {
+    width: 100%;
+  }
 }
+
+
+.geosuggest__suggests-wrapper {
+  position: relative;
+}
+
 .geosuggest__suggests--hidden {
   max-height: 0;
   overflow: hidden;
   border-width: 0;
+  width: 400px;
+  @media (max-width: 639px) {
+    width: 100%;
+    padding-left: 0;
+  }
+  // border: 2px solid red;
+  // box-sizing: border-box;
 }
 
 /**


### PR DESCRIPTION
Refactored Geosuggest and EditProfile to use Bootstrap 4 and Material UI's RaisedButton.

I think we should be using Material UI's [Text Fields](http://www.material-ui.com/#/components/text-field) for the form rather than what we have on the mockups. Specially since we are already using Material UI's Autocomplete for Organization in this form and Autocomplete looks just like Text Fields.

From (mockup):

![image](https://cloud.githubusercontent.com/assets/4016496/20333228/f77c61a4-ab65-11e6-819d-22b0d6bd30e7.png)
to fields that look like this:

![image](https://cloud.githubusercontent.com/assets/4016496/20333261/2c5d377c-ab66-11e6-8a2f-547a0b7d02ae.png)

In this PR we have:

![image](https://cloud.githubusercontent.com/assets/4016496/20333287/5c862a76-ab66-11e6-8c09-1cbe94c2eb01.png)

The idea would be to have all fields look the same,


