### PR TITLE
Optimize bootstrap loading

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import routeConfig from './routes'
 import {Router, browserHistory} from 'react-router'
 import locales from '../public/locales.json'
+import 'bootstrap/dist/css/bootstrap.min.css'
 
 // This replaces the textColor value on the palette
 // and then update the keys for each component that depends on it.

--- a/src/UniversalStyles.scss
+++ b/src/UniversalStyles.scss
@@ -1,4 +1,5 @@
-@import '../node_modules/bootstrap/scss/bootstrap';
+@import '../node_modules/bootstrap/scss/_variables';
+@import '../node_modules/bootstrap/scss/mixins/_breakpoints';
 $color1: #3f51b2;
 $color2: #ff6f00;
 


### PR DESCRIPTION
Import bootstrap CSS at the top level, and only incude variable definitions in UniversalStyles.scss.  Should fix #95
