### PR TITLE
fix #134

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -6,4 +6,5 @@ REACT_APP_API_URL = "http://localhost:3001"
 REACT_APP_UPLOADS_S3_BUCKET = "http://uploads.participedia.xyz.s3-website-us-east-1.amazonaws.com"
 REACT_APP_GOOGLE_MAPS_API=AIzaSyBKcBsz5hg6eQA6iyrogeAKFPfiYiG3iTo
 REACT_APP_ASSETS_URL=https://d3im063erkq9w4.cloudfront.net/
+REACT_APP_UPLOADS_CDN_URL=https://detetf146kq8c.cloudfront.net/
 

--- a/src/Upload.js
+++ b/src/Upload.js
@@ -5,6 +5,7 @@ import { updateUserMetaData } from "./actions";
 import { injectIntl } from "react-intl";
 
 const S3BUCKET_URL = process.env.REACT_APP_UPLOADS_S3_BUCKET;
+const UPLOADS_CDN_URL = process.env.REACT_APP_UPLOADS_CDN_URL;
 
 const box = {
   margin: "1em",
@@ -31,7 +32,7 @@ class Upload extends React.Component {
     if (this.props.updatePicture) {
       dispatch(
         updateUserMetaData(profile.user_id, {
-          customPic: `${S3BUCKET_URL}/${args.filename}`
+          customPic: `${UPLOADS_CDN_URL}cropped-to-square/${args.filename}`
         })
       );
       this.setState({ hidePic: true });


### PR DESCRIPTION
This will use set as the profile URL the cropped version of the uploaded image.  There's still a problem that that image is not available _immediately_ after upload.  Pushing this for now, but we should do something else to display the uploaded image before pre-processing immediately after upload.