### PR TITLE
Usersnap 91 texteditor

### DIFF
--- a/src/components/BodyEditor.js
+++ b/src/components/BodyEditor.js
@@ -63,7 +63,7 @@ class BodyEditor extends React.Component {
           <ReactQuill
             theme="snow"
             onChange={changes =>
-              setTimeout(() => this.props.onChange(changes), 1)}
+              setTimeout(() => this.props.onChange(changes), 0)}
             modules={_quillModules}
             formats={_quillFormats}
             bounds={"._quill"}

--- a/src/components/BodyEditor.js
+++ b/src/components/BodyEditor.js
@@ -62,7 +62,8 @@ class BodyEditor extends React.Component {
           <ScrollEvent handleScrollCallback={this.handleScroll} />
           <ReactQuill
             theme="snow"
-            onChange={this.props.onChange}
+            onChange={changes =>
+              setTimeout(() => this.props.onChange(changes), 1)}
             modules={_quillModules}
             formats={_quillFormats}
             bounds={"._quill"}


### PR DESCRIPTION
We were updating the text from within the onchange event, which is a no-no. Firefox catches the resulting error, but for some reason the exception isn't caught in Chrome. Wrapped the update in a `setTimeout` so it happens outside of the handler and all appears to be well.

Fixes https://github.com/participedia/usersnaps/issues/91