### PR TITLE
fix bug that prevents login when trying to bookmark

### DIFF
--- a/src/components/BookmarkToggle.js
+++ b/src/components/BookmarkToggle.js
@@ -61,7 +61,7 @@ export default class BookmarkToggle extends React.Component {
 
   toggleBookmark(thingType, thingid) {
     if (!authService.isAuthenticated()) {
-      authService.login(this.props.location.pathname);
+      authService.login(window.location.pathname);
     } else {
       let effectSwitch = this.effectSwitch.bind(this);
       if (this.state.bookmarked) {


### PR DESCRIPTION
Quick fix for #651 to trigger login when trying to bookmark an article when not logged in.