### PR TITLE
Fix case premature submit

### DIFF
--- a/src/components/CaseEditor.js
+++ b/src/components/CaseEditor.js
@@ -259,9 +259,6 @@ class CaseEditor extends Component {
                         id: quickSubmitText
                       })}
                     />
-                    <span>
-                      <FormattedMessage id="or" />
-                    </span>
                     <RaisedButton
                       onClick={() => onExpand(this.state.thing)}
                       className="customButton full-submit"


### PR DESCRIPTION
We still need to figure out why the `Edit Full Version` button submits the form as well as changing to the full version form if you put any content between it and the previous button, but for now I'm just taking out the "or" between them so prod won't be broken.

Crazy crazy bug.