### PR TITLE
Jump to beginning of form when "Edit Full Version" is clicked

### DIFF
--- a/src/containers/EditorContainers.js
+++ b/src/containers/EditorContainers.js
@@ -92,6 +92,7 @@ class EditorContainer extends Component {
   }
 
   onExpand(thing) {
+    setTimeout(() => window.scrollTo(0, 0), 1000);
     this.setState({ thing, isQuick: false });
   }
 


### PR DESCRIPTION
Added jump to top of page after a short delay, otherwise rendering (…or navigation?) moves us back down.

I don't like using setTimeout as a rule, because it is dependent on how long things take in a particular browser, but in this case I think it will be OK. Hopefully no-one's browser takes longer than 1 second to render the page, but if it does, things won't break, it just may not position fully at the top.

Fixes #724 