### PR TITLE
722 trim quick submit

### DIFF
--- a/src/__tests__/__snapshots__/Organization-test.js.snap
+++ b/src/__tests__/__snapshots__/Organization-test.js.snap
@@ -501,15 +501,7 @@ exports[`Organization editor renders correctly 1`] = `
                 </p>
                 <div
                   className="list links"
-                >
-                  <div
-                    className="list"
-                  >
-                    <div />
-                    <div />
-                    <div />
-                  </div>
-                </div>
+                />
               </div>
               <h3
                 className="sub-heading"
@@ -669,11 +661,7 @@ exports[`Organization editor renders correctly 1`] = `
                 </p>
                 <div
                   className="list videos"
-                >
-                  <div
-                    className="list"
-                  />
-                </div>
+                />
               </div>
             </div>
           </div>

--- a/src/components/CaseEditor.js
+++ b/src/components/CaseEditor.js
@@ -271,7 +271,7 @@ class CaseEditor extends Component {
                     limit={3}
                     onChange={this.onChange}
                   />
-                  {thing.issues.length ? (
+                  {thing.issues.length && !isQuick ? (
                     <div>
                       <LocalizedMultiChoiceField
                         intl={intl}
@@ -383,10 +383,18 @@ class CaseEditor extends Component {
                     </h3>
                     <ImageListEditor property="images" thing={thing} />
                     {makeLocalizedListField(intl, "videos", "case")}
-                    <h3 className="sub-sub-heading">
-                      <FormattedMessage id="files" />
-                    </h3>
-                    <FileListEditor property="files" thing={thing} />
+                    {!isQuick ? (
+                      <h3 className="sub-sub-heading">
+                        <FormattedMessage id="files" />
+                      </h3>
+                    ) : (
+                      undefined
+                    )}
+                    {!isQuick ? (
+                      <FileListEditor property="files" thing={thing} />
+                    ) : (
+                      undefined
+                    )}
                   </div>
                 </div>
                 <div

--- a/src/components/CaseEditor.js
+++ b/src/components/CaseEditor.js
@@ -255,6 +255,7 @@ class CaseEditor extends Component {
                     <LocalizedMultiChoiceField
                       intl={intl}
                       property="relationships"
+                      value={thing.relationships}
                       rankable={true}
                       limit={3}
                       onChange={this.onChange}
@@ -483,7 +484,7 @@ class CaseEditor extends Component {
                       )}
                       <LocalizedMultiChoiceField
                         intl={intl}
-                        property="participants_interaction"
+                        property="participants_interactions"
                         value={thing.participants_interactions}
                         rankable={true}
                         limit={3}

--- a/src/components/List.scss
+++ b/src/components/List.scss
@@ -1,9 +1,0 @@
-@import "./UniversalStyles";
-
-.sortable-list {
-	list-style-type: none;
-	div {
-		padding-bottom: 0.5rem;
-		cursor: pointer;
-	}
-}

--- a/src/components/PropEditors.js
+++ b/src/components/PropEditors.js
@@ -8,7 +8,8 @@ import { RadioButton, RadioButtonGroup } from "material-ui/RadioButton";
 import { Field } from "simple-react-form";
 import { makeLocalizedChoices } from "./choices";
 import Geosuggest from "react-geosuggest";
-import List from "./List";
+import SimpleList from "./SimpleList";
+import List from "../vendor/react-items-list";
 import Avatar from "material-ui/Avatar";
 import Upload from "../Upload";
 import "./PropEditors.css";
@@ -226,7 +227,7 @@ export class MultiChoiceEditor extends React.Component {
                 onSortEnd={this.onSortEnd}
               />
             ) : (
-              <List items={this.state.value} />
+              <SimpleList items={this.state.value} />
             )
           ) : (
             undefined

--- a/src/components/SimpleList.js
+++ b/src/components/SimpleList.js
@@ -1,12 +1,12 @@
 import React from "react";
-import "./List.css";
+import "./SimpleList.css";
 
-function List(props) {
+function SimpleList(props) {
   return (
-    <div className="list">
+    <div className="simple-list">
       {props.items.map((obj, index) => <div>{obj.text}</div>)}
     </div>
   );
 }
 
-export default List;
+export default SimpleList;

--- a/src/components/SimpleList.scss
+++ b/src/components/SimpleList.scss
@@ -1,0 +1,9 @@
+@import "./UniversalStyles";
+
+.simple-list {
+  list-style-type: none;
+  div {
+    padding-bottom: 0.5rem;
+    cursor: pointer;
+  }
+}

--- a/src/components/case.choices.json
+++ b/src/components/case.choices.json
@@ -93,7 +93,7 @@
     "not_relevant_to_this_type_of_initiative",
     "other"
   ],
-  "participants_interaction": [
+  "participants_interactions": [
     "acting_drama",
     "ask_and_answer_questions",
     "discussion_dialogue_or_deliberation",

--- a/src/locales.json
+++ b/src/locales.json
@@ -714,10 +714,10 @@
     "facilitator_training_instructional": "If yes, were they…",
     "facilitator_training_placeholder":
       "Did facilitators help guide participants?",
-    "participants_interaction": "Type(s) of Interaction among participants",
-    "participants_interaction_instructional":
+    "participants_interactions": "Type(s) of Interaction among participants",
+    "participants_interactions_instructional":
       "Select and rank up to three types of interactions in order of relevance, with with “1” indicating the most often used form of interaction.",
-    "participants_interaction_placeholder":
+    "participants_interactions_placeholder":
       "Select & rank up to 3 types of interaction",
     "learning_resources": "Information and Learning Resources",
     "learning_resources_instructional":


### PR DESCRIPTION
Remove `files` and `specific_topics` from quick submit.

Fixes a couple of the list widgets (including files) along the way.

Fixes #722 
Fixes #717