### PR TITLE
case reader bug and location bug

### DIFF
--- a/src/components/ListWithHeading.js
+++ b/src/components/ListWithHeading.js
@@ -5,7 +5,7 @@ import "./ListWithHeading.css";
 export default class ListGroupWithHeading extends React.Component {
   render() {
     let { heading, property, thing } = this.props;
-    if (!thing[property] || thing[property].length === 0) {
+    if (!thing[property] || thing[property].length === 0 || thing[property][0] === "" ) {
       return <div />;
     }
     let items = thing[property].map(item => (

--- a/src/components/NestedTextListWithHeading.js
+++ b/src/components/NestedTextListWithHeading.js
@@ -9,21 +9,23 @@ export default class NestedTextListGroupWithHeading extends React.Component {
     let value = thing[property];
 
     if (!value || (_.isArray(value) && !value.length)) {
-      return <div />;
+      return null;
     } else {
+      const items = Object.keys(value).map(key => {
+        if (!value[key]) return null;
 
-      let items = _.map(value, value.children);
-      let nests  = items.map(item => (
-        <div key={item.value}>
-          {item}
-        </div>
-      ));
+        // don't display the name key for the location property
+        if (property === "location" && key === "name") return null;
+
+        return <div key={value[key]}>{value[key]}</div>;
+      }).filter(item => item !== null);
+
       return (
         <div className="linked-property isarray">
           <p className="sub-sub-heading">
             <FormattedMessage id={property} />
           </p>
-          <div className={property + " blond"}>{nests}</div>
+          <div className={property + " blond"}>{items}</div>
         </div>
       );
     }


### PR DESCRIPTION
- fixes https://github.com/participedia/usersnaps/issues/331 and similar issues -- result of a react-intl bug where we are passing a null value to the id, which throws this error:
<img width="601" alt="Screenshot 2019-03-12 16 50 47" src="https://user-images.githubusercontent.com/130878/54243762-0693e280-44e7-11e9-80f2-fe5e5edf3b9e.png">

the null value is a result of empty link entries for a case like this. ideally we would strip empty values on the backend, but until then this will fix the reader view.
<img width="676" alt="Screenshot 2019-03-12 16 54 13" src="https://user-images.githubusercontent.com/130878/54243887-71ddb480-44e7-11e9-8a94-88ab22ae269f.png">

- fixes issue with showing location name twice https://github.com/participedia/usersnaps/issues/163
before:
<img width="219" alt="Screenshot 2019-03-11 21 33 47" src="https://user-images.githubusercontent.com/130878/54243912-8b7efc00-44e7-11e9-89f9-01f1a672b1e6.png">

after:
<img width="279" alt="Screenshot 2019-03-11 21 56 19" src="https://user-images.githubusercontent.com/130878/54243931-95a0fa80-44e7-11e9-96ce-ce271ba151df.png">


